### PR TITLE
Add Ruby Underground Tel Aviv to map

### DIFF
--- a/data/seeds/organizations.yml
+++ b/data/seeds/organizations.yml
@@ -160,3 +160,8 @@
   url: http://charlotteruby.org
   locations:
     - address: Charlotte, NC
+- name: Ruby Underground Israel
+  type: meetup
+  url: https://www.meetup.com/IsraelRubyUnderground/
+  locations:
+    - address: Tel Aviv, Israel


### PR DESCRIPTION
This PR adds the Ruby Tel Aviv meetup to the map. 