### PR TITLE
Add sort-orgs.rb script to sort organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Sometimes folks are interested in finding a new gig, in a new location. Ruby Map
 What if your company / meetup / event is missing on the map? No problem, just send us a PR and it will get added asap.
 An example PR can be found [here](https://github.com/lewispb/rubymap/pull/1).
 
+Please try to maintain the order-by-name of the yaml file, to prevent merge conflicts.
+
 ## Prerequisites
 
 ```bash

--- a/bin/sort-orgs.rb
+++ b/bin/sort-orgs.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/ruby
+
+# Replaces the organizations.yml file with its data sorted by name, case insensitively.
+# Before overwriting the file, tests that the unsorted and sorted data,
+# converted to sets, are equal.
+
+require 'set'
+require 'yaml'
+
+def test(unsorted, sorted)
+  if Set.new(unsorted) != Set.new(sorted)
+    raise "Sort corrupted the data."
+  end
+end
+
+def sort_orgs_case_insensitively(orgs)
+  orgs.sort { |org1, org2| org1['name'].casecmp(org2['name']) }
+end
+
+def filespec
+  ARGV[0] || 'organizations.yml'
+end
+
+
+orgs = YAML.load_file(filespec)
+sorted_orgs = sort_orgs_case_insensitively(orgs)
+
+# Enable this line to verify that the test that tests for data corruption works:
+# sorted_orgs.pop 
+
+test(orgs, sorted_orgs)
+File.write(filespec, sorted_orgs.to_yaml)

--- a/bin/sort-orgs.rb
+++ b/bin/sort-orgs.rb
@@ -7,26 +7,43 @@
 require 'set'
 require 'yaml'
 
+def orgs_filespec
+  @orgs_filespec ||= begin
+    project_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+    File.join(project_root, 'data', 'seeds', 'organizations.yml')
+  end
+end
+
+
 def test(unsorted, sorted)
   if Set.new(unsorted) != Set.new(sorted)
     raise "Sort corrupted the data."
   end
 end
 
+
 def sort_orgs_case_insensitively(orgs)
   orgs.sort { |org1, org2| org1['name'].casecmp(org2['name']) }
 end
 
-def filespec
-  ARGV[0] || 'organizations.yml'
+
+def main
+  orgs = YAML.load_file(orgs_filespec)
+  sorted_orgs = sort_orgs_case_insensitively(orgs)
+
+  if orgs == sorted_orgs
+    puts "File was already sorted. No need to overwrite."
+    exit(0)
+  else
+
+    # Enable this line to verify that the test that tests for data corruption works:
+    # sorted_orgs.pop
+
+    test(orgs, sorted_orgs)
+    File.write(orgs_filespec, sorted_orgs.to_yaml)
+    puts "Organizations file sort successful."
+  end
 end
 
 
-orgs = YAML.load_file(filespec)
-sorted_orgs = sort_orgs_case_insensitively(orgs)
-
-# Enable this line to verify that the test that tests for data corruption works:
-# sorted_orgs.pop 
-
-test(orgs, sorted_orgs)
-File.write(filespec, sorted_orgs.to_yaml)
+main


### PR DESCRIPTION
Addresses https://github.com/lewispb/rubymap/issues/51.

Organizations are in random sort order making them more difficult to find. This will become more and more of an issue as the list grows.

When this script is run, it will sort the organizations by name case insensitively, overwriting the original content with the sorted content.

To test that data has not been corrupted during sorting, it creates and compares sets with both original and sorted arrays, aborting before overwriting if the sets are not equal.