### PR TITLE
Add Renuo

### DIFF
--- a/data/seeds/organizations.yml
+++ b/data/seeds/organizations.yml
@@ -248,3 +248,8 @@
   url: https://stormconsultancy.co.uk/
   locations:
     - address: 14 New Bond St, Bath, BA1 1BE, United Kingdom
+- name: Renuo
+  type: business
+  url: https://www.renuo.ch/
+  locations:
+    - address: Industriestrasse 44, Wallisellen, Switzerland


### PR DESCRIPTION
We're a web agency developing with Rails since 2011. We also carry some of the organization of the [Railshöck Schweiz](https://www.meetup.com/rubyonrails-ch/). The maintainer of Cancancan works at Renuo and owns parts of it.