### PR TITLE
Add RubyMonstas Zurich to organizations

### DIFF
--- a/data/seeds/organizations.yml
+++ b/data/seeds/organizations.yml
@@ -203,7 +203,7 @@
   locations:
     - address: Tel Aviv, Israel
 - name: Vanruby
-  type: meetup 
+  type: meetup
   url: http://vanruby.org
   locations:
     - address: Vancouver, BC, Canada
@@ -248,3 +248,8 @@
   url: https://stormconsultancy.co.uk/
   locations:
     - address: 14 New Bond St, Bath, BA1 1BE, United Kingdom
+- name: Ruby Monstas Zurich
+  type: meetup
+  url: https://rubymonstas.ch/
+  locations:
+    - address: Zurich, Switzerland


### PR DESCRIPTION
[Ruby Monstas Zurich](https://rubymonstas.ch/) stands for Ruby Monday Study Group’stas in Zurich.

It is inspired by the original Ruby Monstas Berlin.

We all know there are still not even remotely enough women in tech and we decided to do something about it. Our team has helped in organising and coaching at Rails Girls events but we felt we wanted to take the idea one step further. We want to host a regular Ruby study group for beginners!

If you identify as a woman, and want to learn programming Ruby, learn how to build a web application, or are otherwise interested in joining or supporting our group, then feel free to get in touch with us.

We host regular events every Monday in Zurich, Switzerland.