### PR TITLE
Add RubyZG meetup

### DIFF
--- a/data/seeds/organizations.yml
+++ b/data/seeds/organizations.yml
@@ -437,3 +437,8 @@
   url: https://guava.software
   locations:
   - address: R. Alfredo Coutinho, 74 - Poço da Panela, Recife, Pernambuco, Brasil
+- name: RubyZG
+  type: meetup
+  url: https://www.meetup.com/rubyzg/
+  locations:
+  - address: Zagreb, Croatia


### PR DESCRIPTION
This patch adds the RubyZG meetup in Zagreb, Croatia
https://www.meetup.com/rubyzg/